### PR TITLE
Make setup instructions easier to follow

### DIFF
--- a/docs/shared/ccloud_setup.md
+++ b/docs/shared/ccloud_setup.md
@@ -1,3 +1,3 @@
-Setup your environment in [Confluent Cloud](https://www.confluent.io/confluent-cloud/tryfree/?utm_source=github&utm_medium=ksqldb_recipes), a fully-managed Apache Kafka® service, and within your environment create a [ksqlDB](https://ksqldb.io/) application.
+Setup your environment in [Confluent Cloud](https://www.confluent.io/confluent-cloud/tryfree/?utm_source=github&utm_medium=ksqldb_recipes), a fully-managed Apache Kafka® service.
 
-ksqlDB supports a `SQL` language for processing the data in real-time (and will soon support connector integration for reading and writing data to other data sources and sinks). Execute the recipe with the provided `SQL` commands using the Confluent Cloud ksqlDB editor. 
+Once your Confluent Cloud cluster is available, create a [ksqlDB](https://ksqldb.io/) application. ksqlDB supports a `SQL` language for processing the data in real-time (and will soon support connector integration for reading and writing data to other data sources and sinks). Execute the recipe with the provided `SQL` commands using the Confluent Cloud ksqlDB editor. 

--- a/docs/shared/ccloud_setup.md
+++ b/docs/shared/ccloud_setup.md
@@ -1,3 +1,3 @@
-Setup your environment in [Confluent Cloud](https://www.confluent.io/confluent-cloud/tryfree/?utm_source=github&utm_medium=ksqldb_recipes), a fully-managed Apache Kafka® service.
+Setup your environment in [Confluent Cloud](https://www.confluent.io/confluent-cloud/tryfree/?utm_source=github&utm_medium=ksqldb_recipes), a fully-managed Apache Kafka<sup>®</sup> service.
 
 Once your Confluent Cloud cluster is available, create a [ksqlDB](https://ksqldb.io/) application. ksqlDB supports a `SQL` language for processing the data in real-time (and will soon support connector integration for reading and writing data to other data sources and sinks). Execute the recipe with the provided `SQL` commands using the Confluent Cloud ksqlDB editor. 


### PR DESCRIPTION
There are two distinct the user has to do: 
1. Create CCLoud clsuter
2. Create ksqlDB app

if it's in a single para, with the "a fully-managed Apache Kafka® service." in between, it's easier to miss the second point.